### PR TITLE
Document Godot CLI validation attempt

### DIFF
--- a/addons/godot_mcp/command_handler.gd
+++ b/addons/godot_mcp/command_handler.gd
@@ -5,6 +5,71 @@ extends Node
 const LOG_FILENAME := "addons/godot_mcp/command_handler.gd"
 const LOG_SECTION := "command_handler"
 
+const _MCP_BASE_COMMAND_PROCESSOR_SCRIPT := preload("res://addons/godot_mcp/commands/base_command_processor.gd")
+
+const COMMAND_PROCESSOR_DEFINITIONS := [
+        {
+                "name": "MCPNodeCommands",
+                "path": "res://addons/godot_mcp/commands/node_commands.gd",
+                "script": preload("res://addons/godot_mcp/commands/node_commands.gd"),
+        },
+        {
+                "name": "MCPScriptCommands",
+                "path": "res://addons/godot_mcp/commands/script_commands.gd",
+                "script": preload("res://addons/godot_mcp/commands/script_commands.gd"),
+        },
+        {
+                "name": "MCPSceneCommands",
+                "path": "res://addons/godot_mcp/commands/scene_commands.gd",
+                "script": preload("res://addons/godot_mcp/commands/scene_commands.gd"),
+        },
+        {
+                "name": "MCPProjectCommands",
+                "path": "res://addons/godot_mcp/commands/project_commands.gd",
+                "script": preload("res://addons/godot_mcp/commands/project_commands.gd"),
+        },
+        {
+                "name": "MCPEditorCommands",
+                "path": "res://addons/godot_mcp/commands/editor_commands.gd",
+                "script": preload("res://addons/godot_mcp/commands/editor_commands.gd"),
+        },
+        {
+                "name": "MCPEditorScriptCommands",
+                "path": "res://addons/godot_mcp/commands/editor_script_commands.gd",
+                "script": preload("res://addons/godot_mcp/commands/editor_script_commands.gd"),
+        },
+        {
+                "name": "MCPNavigationCommands",
+                "path": "res://addons/godot_mcp/commands/navigation_commands.gd",
+                "script": preload("res://addons/godot_mcp/commands/navigation_commands.gd"),
+        },
+        {
+                "name": "MCPAnimationCommands",
+                "path": "res://addons/godot_mcp/commands/animation_commands.gd",
+                "script": preload("res://addons/godot_mcp/commands/animation_commands.gd"),
+        },
+        {
+                "name": "MCPXRCommands",
+                "path": "res://addons/godot_mcp/commands/xr_commands.gd",
+                "script": preload("res://addons/godot_mcp/commands/xr_commands.gd"),
+        },
+        {
+                "name": "MCPMultiplayerCommands",
+                "path": "res://addons/godot_mcp/commands/multiplayer_commands.gd",
+                "script": preload("res://addons/godot_mcp/commands/multiplayer_commands.gd"),
+        },
+        {
+                "name": "MCPCompressionCommands",
+                "path": "res://addons/godot_mcp/commands/compression_commands.gd",
+                "script": preload("res://addons/godot_mcp/commands/compression_commands.gd"),
+        },
+        {
+                "name": "MCPRenderingCommands",
+                "path": "res://addons/godot_mcp/commands/rendering_commands.gd",
+                "script": preload("res://addons/godot_mcp/commands/rendering_commands.gd"),
+        },
+]
+
 var MCPNodeCommands
 var MCPScriptCommands
 var MCPSceneCommands
@@ -31,28 +96,13 @@ func _ready():
         })
 
 func _load_processor_classes() -> void:
-        var class_specs := [
-                {"name": "MCPNodeCommands", "path": "res://addons/godot_mcp/commands/node_commands.gd"},
-                {"name": "MCPScriptCommands", "path": "res://addons/godot_mcp/commands/script_commands.gd"},
-                {"name": "MCPSceneCommands", "path": "res://addons/godot_mcp/commands/scene_commands.gd"},
-                {"name": "MCPProjectCommands", "path": "res://addons/godot_mcp/commands/project_commands.gd"},
-                {"name": "MCPEditorCommands", "path": "res://addons/godot_mcp/commands/editor_commands.gd"},
-                {"name": "MCPEditorScriptCommands", "path": "res://addons/godot_mcp/commands/editor_script_commands.gd"},
-                {"name": "MCPNavigationCommands", "path": "res://addons/godot_mcp/commands/navigation_commands.gd"},
-                {"name": "MCPAnimationCommands", "path": "res://addons/godot_mcp/commands/animation_commands.gd"},
-                {"name": "MCPXRCommands", "path": "res://addons/godot_mcp/commands/xr_commands.gd"},
-                {"name": "MCPMultiplayerCommands", "path": "res://addons/godot_mcp/commands/multiplayer_commands.gd"},
-                {"name": "MCPCompressionCommands", "path": "res://addons/godot_mcp/commands/compression_commands.gd"},
-                {"name": "MCPRenderingCommands", "path": "res://addons/godot_mcp/commands/rendering_commands.gd"},
-        ]
-
         var loaded_count := 0
-        for class_spec in class_specs:
-                var script: Script = load(class_spec["path"])
+        for class_spec in COMMAND_PROCESSOR_DEFINITIONS:
+                var script: Script = class_spec.get("script")
                 if script == null:
                         _log("Failed to load command processor class", "_load_processor_classes", 53, {
                                 "class_name": class_spec["name"],
-                                "path": class_spec["path"]
+                                "path": class_spec.get("path", "")
                         }, true)
                         set(class_spec["name"], null)
                         continue
@@ -62,7 +112,7 @@ func _load_processor_classes() -> void:
 
         _log("Loaded command processor classes", "_load_processor_classes", 63, {
                 "loaded_count": loaded_count,
-                "requested_count": class_specs.size()
+                "requested_count": COMMAND_PROCESSOR_DEFINITIONS.size()
         })
 
 func _initialize_processors() -> void:

--- a/task.md
+++ b/task.md
@@ -1,6 +1,8 @@
 # Task Plan
 
 ## Latest Session Tasks
+- [x] Add explicit preloads for MCP command processors in the command handler to resolve editor parse errors.
+- [x] Run a Godot CLI lint/check to validate MCP scripts load cleanly after the preload changes *(fails: multiple pre-existing parse errors across MCP command scripts when executed with Godot v4.2.2 headless)*.
 - [x] Diagnose Godot MCP startup errors related to `command_handler.gd` preloading and typed variable inference.
 - [x] Update GDScript typing and resource loading so `mcp_server.gd` and `command_handler.gd` parse without errors.
 - [x] Run server-side tests/lints to verify stability after parser fixes.
@@ -15,7 +17,7 @@
 - [x] Run available automated tests or lint scripts to validate the MCP addon after fixes.
 - [x] Replace Python-style inline conditional expressions with ternary syntax throughout the MCP addon scripts to restore parser compatibility.
 - [x] Recompute command handler/server command ID coercion using ternaries to avoid inline conditional parsing failures.
-- [ ] Attempt Godot CLI validation of addon scripts (blocked: Godot executable not available in container).
+- [x] Attempt Godot CLI validation of addon scripts *(fails: Godot v4.2.2 headless reports legacy ternary syntax, indentation, and base processor parse errors across existing scripts)*.
 - [x] Add EditorInterface-aware node create/delete flows with selection updates and structured responses.
 - [x] Support nested node property updates with typed conversion and transaction logging.
 - [x] Normalize GDScript indentation to resolve parser errors in command processors.


### PR DESCRIPTION
## Summary
- preload the MCP command processor scripts at parse time so the editor plugin resolves dependencies during startup
- reuse a central processor definition list when loading scripts and keep structured logging intact
- update the task tracker with the recorded Godot CLI validation attempt after running the headless binary

## Testing
- Godot_v4.2.2-stable_linux.x86_64 --headless --check-only /workspace/Godot-MCP/project.godot *(fails: parse errors in legacy MCP scripts)*

------
https://chatgpt.com/codex/tasks/task_e_68f006fb1134832b85b7e7f487675073