### PR TITLE
Fix command handler ternary for Godot 4 parsing

### DIFF
--- a/addons/godot_mcp/command_handler.gd
+++ b/addons/godot_mcp/command_handler.gd
@@ -161,7 +161,7 @@ func _handle_command(client_id: int, command: Dictionary) -> void:
         if typeof(command_id_value) == TYPE_STRING:
                 command_id = command_id_value
         else:
-                command_id = command_id_value != null ? str(command_id_value) : ""
+                command_id = str(command_id_value) if command_id_value != null else ""
 
         if command_type.is_empty():
                 _log("Missing command type", "_handle_command", 117, {

--- a/task.md
+++ b/task.md
@@ -1,6 +1,9 @@
 # Task Plan
 
 ## Latest Session Tasks
+- [x] Investigate the reported preload failure for `command_handler.gd` in the MCP server startup logs.
+- [x] Replace any legacy inline conditional syntax that prevents `command_handler.gd` from parsing under Godot 4.
+- [x] Run the available automated test suite to ensure no regressions after the parser fix.
 - [x] Add explicit preloads for MCP command processors in the command handler to resolve editor parse errors.
 - [x] Run a Godot CLI lint/check to validate MCP scripts load cleanly after the preload changes *(fails: multiple pre-existing parse errors across MCP command scripts when executed with Godot v4.2.2 headless)*.
 - [x] Diagnose Godot MCP startup errors related to `command_handler.gd` preloading and typed variable inference.


### PR DESCRIPTION
## Summary
- update the MCP command handler to use Godot 4 compatible inline conditional syntax when coercing command IDs
- document the investigation, fix, and verification tasks in task.md for traceability

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68f0103fefb0832b93f89348178d51fd