### PR TITLE
Fix MCP command indentation parse errors

### DIFF
--- a/addons/godot_mcp/commands/base_command_processor.gd
+++ b/addons/godot_mcp/commands/base_command_processor.gd
@@ -103,42 +103,42 @@ func _get_undo_redo():
 # Helper function to parse property values from string to proper Godot types
 func _parse_property_value(value):
 	# Only try to parse strings that look like they could be Godot types
-	if (
-		typeof(value) == TYPE_STRING
-		and (
-			value.begins_with("Vector")
-			or value.begins_with("Transform")
-			or value.begins_with("Rect")
-			or value.begins_with("Color")
-			or value.begins_with("Quat")
-			or value.begins_with("Basis")
-			or value.begins_with("Plane")
-			or value.begins_with("AABB")
-			or value.begins_with("Projection")
-			or value.begins_with("Callable")
-			or value.begins_with("Signal")
-			or value.begins_with("PackedVector")
-			or value.begins_with("PackedString")
-			or value.begins_with("PackedFloat")
-			or value.begins_with("PackedInt")
-			or value.begins_with("PackedColor")
-			or value.begins_with("PackedByteArray")
-			or value.begins_with("Dictionary")
-			or value.begins_with("Array")
-		)
-	):
-	var expression = Expression.new()
-	var error = expression.parse(value, [])
+        if (
+                typeof(value) == TYPE_STRING
+                and (
+                        value.begins_with("Vector")
+                        or value.begins_with("Transform")
+                        or value.begins_with("Rect")
+                        or value.begins_with("Color")
+                        or value.begins_with("Quat")
+                        or value.begins_with("Basis")
+                        or value.begins_with("Plane")
+                        or value.begins_with("AABB")
+                        or value.begins_with("Projection")
+                        or value.begins_with("Callable")
+                        or value.begins_with("Signal")
+                        or value.begins_with("PackedVector")
+                        or value.begins_with("PackedString")
+                        or value.begins_with("PackedFloat")
+                        or value.begins_with("PackedInt")
+                        or value.begins_with("PackedColor")
+                        or value.begins_with("PackedByteArray")
+                        or value.begins_with("Dictionary")
+                        or value.begins_with("Array")
+                )
+        ):
+                var expression = Expression.new()
+                var error = expression.parse(value, [])
 
-	if error == OK:
-		var result = expression.execute([], null, true)
-		if not expression.has_execute_failed():
-			print("Successfully parsed %s as %s" % [value, result])
-			return result
-		else:
-			print("Failed to execute expression for: %s" % value)
-	else:
-		print("Failed to parse expression: %s (Error: %d)" % [value, error])
+                if error == OK:
+                        var result = expression.execute([], null, true)
+                        if not expression.has_execute_failed():
+                                print("Successfully parsed %s as %s" % [value, result])
+                                return result
+                        else:
+                                print("Failed to execute expression for: %s" % value)
+                else:
+                        print("Failed to parse expression: %s (Error: %d)" % [value, error])
 
 # Otherwise, return value as is
 	return value

--- a/addons/godot_mcp/commands/node_commands.gd
+++ b/addons/godot_mcp/commands/node_commands.gd
@@ -119,12 +119,12 @@ func _rename_node(client_id: int, params: Dictionary, command_id: String) -> voi
 	)
 
 	if transaction_id.is_empty():
-		if not transaction.commit():
-			transaction.rollback()
-			return _send_error(client_id, "Failed to commit node rename", command_id)
+                if not transaction.commit():
+                        transaction.rollback()
+                        return _send_error(client_id, "Failed to commit node rename", command_id)
 
-				var updated_path = node.get_path()
-				var path_string = typeof(updated_path) == TYPE_STRING ? updated_path : updated_path.to_string()
+                var updated_path = node.get_path()
+                var path_string = typeof(updated_path) == TYPE_STRING ? updated_path : updated_path.to_string()
 		_send_success(client_id, {
 			"previous_name": old_name,
 			"new_name": new_name,

--- a/task.md
+++ b/task.md
@@ -1,6 +1,9 @@
 # Task Plan
 
 ## Latest Session Tasks
+- [x] Restore indentation within `_parse_property_value` so `base_command_processor.gd` registers its global class correctly.
+- [x] Align `_rename_node` commit handling indentation in `node_commands.gd` to avoid parser failures.
+- [ ] Run headless plugin load smoke test after indentation fixes *(blocked: Godot CLI binary unavailable in environment).* 
 - [x] Investigate Godot 4.4.1 parse errors preventing MCP command processors from loading.
 - [x] Normalize MCP base command processor indentation so class registration succeeds in Godot 4.
 - [ ] Run available automated checks to confirm the MCP addon parses after indentation fixes. *(blocked: pytest requires missing 'websockets' dependency).*


### PR DESCRIPTION
## Summary
- restore indentation inside `_parse_property_value` so the base command processor loads correctly
- realign `_rename_node` commit handling in `node_commands.gd` to keep the parser happy
- document the fixes in `task.md`

## Testing
- `godot --headless --script test_plugin_load.gd` *(fails: `godot` binary not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f049b12cdc832b990d49cdfecb811a